### PR TITLE
implement readADResultRaw() function

### DIFF
--- a/AD770X.h
+++ b/AD770X.h
@@ -77,6 +77,7 @@ public:
     void setNextOperation(byte reg, byte channel, byte readWrite);
     void writeClockRegister(byte CLKDIS, byte CLKDIV, byte outputUpdateRate);
     void writeSetupRegister(byte operationMode, byte gain, byte unipolar, byte buffered, byte fsync);
+    unsigned int readADResultRaw(byte channel);
     double readADResult(byte channel, float refOffset = 0.0);
     void reset();
     bool dataReady(byte channel);

--- a/AD770x.cpp
+++ b/AD770x.cpp
@@ -61,12 +61,16 @@ unsigned int AD770X::readADResult() {
     return r;
 }
 
-double AD770X::readADResult(byte channel, float refOffset) {
+unsigned int AD770X::readADResultRaw(byte channel) {
     while (!dataReady(channel)) {
     };
     setNextOperation(REG_DATA, channel, 1);
 
-    return readADResult() * 1.0 / 65536.0 * VRef - refOffset;
+    return readADResult();
+}
+
+double AD770X::readADResult(byte channel, float refOffset) {
+    return readADResultRaw(channel) * 1.0 / 65536.0 * VRef - refOffset;
 }
 
 bool AD770X::dataReady(byte channel) {


### PR DESCRIPTION
Function readADResultRaw() returns unsigned int value.
Function readADResult() now will use readADResultRaw().
